### PR TITLE
make trx from zip

### DIFF
--- a/mosbuild_worker.sh
+++ b/mosbuild_worker.sh
@@ -387,8 +387,8 @@ STEP_3B_4 () {
 
 	echo "** Compile trx"
 	DEBIAN_FRONTEND=noninteractive apt-get -y install libopus-dev
-	cp ./moode/other/trx/trx-0.4.tar.gz ./
-	tar xfz ./trx-0.4.tar.gz
+	cp ./moode/other/trx/trx-0.4.zip ./
+	tar xfz ./trx-0.4.zip
 	cd trx-0.4
 	make
 	if [ $? -ne 0 ] ; then


### PR DESCRIPTION
Trx.tar.gz does not exist, use zip instead
Don't forget to change line 391 to "unzip -q" 