### PR TITLE
Use armv6l librespot, because that's what latest moode zips contain.

### DIFF
--- a/mosbuild.properties
+++ b/mosbuild.properties
@@ -33,7 +33,7 @@ KERNEL_HASH=87fea11838d706311dc3708d67c334967505a292
 MPD_BIN=mpd-0.21.22
 SPS_BIN=shairport-sync-3.3.6-15fd1d0
 SL_BIN=squeezelite-1.8.7-1052
-LR_BIN=librespot-0.1.1-armv7l
+LR_BIN=librespot-0.1.1-armv6l
 MINIDLNA_BIN=minidlnad-1.2.1+0763719
 
 # Dynamically added properties


### PR DESCRIPTION
I tried to use mosbuild to build a moode image with some changes I'd made, and it failed to include librespot. Looks like that's because the moode repo now just includes the armv6l binary, but mosbuild.properties defaults to specifying armv7l.